### PR TITLE
🐛 GNB스크롤에서 곱셈 연산으로 인해 발생했던 버그 해결

### DIFF
--- a/src/js/gnb.js
+++ b/src/js/gnb.js
@@ -28,23 +28,25 @@ function handleScroll() {
 function handleScrollUp(startPoint, endPoint) {
   var distance = startPoint + 1;
   var scroller = setInterval(function () {
-    distance -= Math.ceil(distance * 0.05);
-    window.scrollTo(0, distance);
-    if (distance <= endPoint) {
+    if (distance <= endPoint + 1) {
       clearInterval(scroller);
+      window.scrollTo(0, endPoint);
       return;
     }
+    distance -= Math.ceil(distance * 0.05);
+    window.scrollTo(0, distance);
   }, 5);
 }
 function handleScrollDown(startPoint, endPoint) {
   var distance = startPoint + 1;
   var scroller = setInterval(function () {
-    distance += Math.ceil(distance * 0.05);
-    window.scrollTo(0, distance);
     if (distance >= endPoint) {
       clearInterval(scroller);
+      window.scrollTo(0, endPoint);
       return;
     }
+    distance += Math.ceil(distance * 0.05);
+    window.scrollTo(0, distance);
   });
 }
 


### PR DESCRIPTION
## 세부 사항
- 곱셈 연산으로 인해 distance+1을 해줬었는데, 이로 인해 조건문에서 정확한 값을 잡아내지 못해 스크롤이 깜빡거리는 문제가 발생했었습니다. 이를 endPoint에도 동일하게 +1을 해줘 문제를 해결했습니다.

## 기타 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점 및 공유할 내용)
- 없습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.